### PR TITLE
Fix fdset memory leak

### DIFF
--- a/ext/typhoeus/typhoeus_multi.c
+++ b/ext/typhoeus/typhoeus_multi.c
@@ -179,6 +179,10 @@ static VALUE multi_perform(VALUE self) {
 
   }
 
+  rb_fd_term (&fdread);
+  rb_fd_term (&fdwrite);
+  rb_fd_term (&fdexcep);
+
   return Qnil;
 }
 


### PR DESCRIPTION
Problem introduced in:
https://github.com/skaes/typhoeus/commit/6d6967fab6b5060a3609394f8682ac37263cf752

We need to call rb_fd_term to free the memory:
http://rxr.whitequark.org/mri/source/thread.c?v=2.1.2#3183

Got the idea via this similar bug in eventmachine:
https://github.com/eventmachine/eventmachine/pull/586